### PR TITLE
chore: relicense from MIT to Apache-2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,25 +1,25 @@
 LDaCA Wordflow
-Copyright 2024-2026 The University of Sydney and LDaCA Wordflow contributors
+Copyright 2025-2026 Language Data Commons of Australia (LDaCA)
+Copyright 2025-2026 Sydney Informatics Hub, The University of Sydney
 
-This product includes software developed at:
-  - Sydney Informatics Hub, The University of Sydney
-    (https://www.sydney.edu.au/research/facilities/sydney-informatics-hub.html)
-  - Sydney Corpus Lab, The University of Sydney
-    (https://sydneycorpuslab.com/)
-
-LDaCA Wordflow is part of the Language Data Commons of Australia (LDaCA,
-https://www.ldaca.edu.au), funded by the Australian Research Data Commons
-(ARDC) and enabled by the National Collaborative Research Infrastructure
-Strategy (NCRIS).
-
-Wordflow extends earlier analytical work by the Australian Text Analytics
-Platform (ATAP, https://www.atap.edu.au), an earlier ARDC-funded
-text-analytics initiative that has since been merged into LDaCA. The
-analytical design lineage and core development team have carried through
-unchanged. The GitHub organisation name "Australian-Text-Analytics-Platform"
-reflects that legacy ATAP origin.
+Developed by Sydney Informatics Hub (SIH) and Sydney Corpus Lab (SCL),
+The University of Sydney, for the Language Data Commons of Australia
+(LDaCA, https://www.ldaca.edu.au) — a national research infrastructure
+project funded by the Australian Research Data Commons (ARDC) and
+enabled by the National Collaborative Research Infrastructure Strategy
+(NCRIS). LDaCA was established in 2021; the Wordflow application was
+started from scratch in 2025, reusing analytical ideas from the
+Australian Text Analytics Platform (ATAP, https://www.atap.edu.au)
+whose tools have been folded into LDaCA. The GitHub organisation name
+"Australian-Text-Analytics-Platform" reflects that legacy ATAP origin.
 
 This product bundles components published under their own permissive
 licenses (MIT or MIT/Apache-2.0 dual): polars, FastAPI, React, Tauri,
-polars-text, docworkspace, and many others. Each is included subject to
-its own copyright notice and license terms.
+and others. Each is included subject to its own copyright notice and
+license terms. The sibling LDaCA-developed packages polars-text and
+docworkspace are also distributed under the Apache 2.0 license; see
+their respective LICENSE and NOTICE files for attribution.
+
+If you use LDaCA Wordflow in research, please cite both the LDaCA
+project and the Wordflow tool. See the in-app "Cite LDaCA Wordflow"
+panel or the project's README for the recommended citation form.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,25 @@
+LDaCA Wordflow
+Copyright 2024-2026 The University of Sydney and LDaCA Wordflow contributors
+
+This product includes software developed at:
+  - Sydney Informatics Hub, The University of Sydney
+    (https://www.sydney.edu.au/research/facilities/sydney-informatics-hub.html)
+  - Sydney Corpus Lab, The University of Sydney
+    (https://sydneycorpuslab.com/)
+
+LDaCA Wordflow is part of the Language Data Commons of Australia (LDaCA,
+https://www.ldaca.edu.au), funded by the Australian Research Data Commons
+(ARDC) and enabled by the National Collaborative Research Infrastructure
+Strategy (NCRIS).
+
+Wordflow extends earlier analytical work by the Australian Text Analytics
+Platform (ATAP, https://www.atap.edu.au), an earlier ARDC-funded
+text-analytics initiative that has since been merged into LDaCA. The
+analytical design lineage and core development team have carried through
+unchanged. The GitHub organisation name "Australian-Text-Analytics-Platform"
+reflects that legacy ATAP origin.
+
+This product bundles components published under their own permissive
+licenses (MIT or MIT/Apache-2.0 dual): polars, FastAPI, React, Tauri,
+polars-text, docworkspace, and many others. Each is included subject to
+its own copyright notice and license terms.

--- a/README.md
+++ b/README.md
@@ -141,3 +141,13 @@ npm run test -w frontend -- --run
 - Backend docs: `backend/docs/index.md`
 - Frontend docs: `frontend/docs/index.md`
 - Agent workflow and repo-specific coding guidance: `AGENTS.md`
+
+## License
+
+LDaCA Wordflow is licensed under the [Apache License, Version 2.0](./LICENSE). See [NOTICE](./NOTICE) for required attribution.
+
+In short: you are free to use, modify, and redistribute Wordflow — including for commercial purposes — provided that you preserve the copyright and license notices, mark any changed files as modified, and carry forward the NOTICE attribution in your own distribution. Apache 2.0 also includes an explicit patent grant from contributors.
+
+Wordflow's nested components ship under their own permissive licenses (MIT or MIT/Apache-2.0 dual): `polars`, `polars-text`, `docworkspace`, `FastAPI`, `React`, `Tauri`, and others. Each is honored by its own copyright notice.
+
+If you use LDaCA Wordflow in research, please cite it — see the in-app "Cite LDaCA Wordflow" page or [frontend/public/references/general.md](./frontend/public/references/general.md).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "vite"
   ],
   "author": "Australian Text Analytics Platform",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "bin": {
     "ldaca_wordflow_frontend": "./bin/cli.js",
     "ldaca_web_app_frontend": "./bin/cli.js",

--- a/frontend/public/information/general.md
+++ b/frontend/public/information/general.md
@@ -7,3 +7,9 @@ Wordflow is a web-based platform that helps you explore and analyse text collect
 Your work is organised into **workspaces**. Each workspace keeps your uploaded data, processed results, and derived outputs together so you can pick up where you left off. Results from one tool can be fed directly into another, making it easy to combine different types of analysis.
 
 No programming or command-line knowledge is required. The platform is designed for researchers across all disciplines.
+
+## License
+
+LDaCA Wordflow is open source under the **Apache License 2.0**. You are free to use, modify, and redistribute it — including for commercial purposes — as long as you keep the copyright and license notices intact and pass on the attribution in the bundled `NOTICE` file.
+
+The full license text ships with every installation as the `LICENSE` and `NOTICE` files alongside the application, and is also available in the project's [GitHub repository](https://github.com/Australian-Text-Analytics-Platform/ldaca-wordflow/blob/main/LICENSE).

--- a/frontend/public/references/general.md
+++ b/frontend/public/references/general.md
@@ -53,6 +53,16 @@ These contributions have been essential in ensuring that LDaCA Wordflow meets th
 
 ---
 
+## License
+
+LDaCA Wordflow is licensed under the **Apache License, Version 2.0**. See the bundled [`LICENSE`](https://github.com/Australian-Text-Analytics-Platform/ldaca-wordflow/blob/main/LICENSE) and [`NOTICE`](https://github.com/Australian-Text-Analytics-Platform/ldaca-wordflow/blob/main/NOTICE) files, or the canonical license text at [apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+Apache 2.0 is a permissive open-source licence: you are free to use, modify, and redistribute Wordflow — including for commercial purposes — provided that you preserve the copyright and licence notices, mark any changed files as modified, and pass the `NOTICE` attribution forward in your own distribution. The licence also grants an explicit patent licence from contributors covering their contributions.
+
+Wordflow's nested components are distributed under their own permissive licences (MIT or MIT/Apache-2.0 dual), including `polars`, `polars-text`, `docworkspace`, `FastAPI`, `React`, and `Tauri`.
+
+---
+
 © Language Data Commons of Australia (LDaCA)
 
 Version {{VERSION}} - released on {{BUILD_DATE}}.

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -3,6 +3,7 @@ name = "ldaca-wordflow"
 version = "0.5.1"
 description = "LDaCA Wordflow Desktop Application"
 authors = ["Australian Text Analytics Platform"]
+license = "Apache-2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ name = "ldaca-wordflow-workspace"
 version = "0.5.1"
 description = "LDaCA Wordflow Workspace"
 requires-python = ">=3.14"
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE"]
 dependencies = ["ldaca-wordflow", "ldaca-loader"]
 
 [tool.uv.sources]


### PR DESCRIPTION
## Summary

Switches LDaCA Wordflow's declared open-source licence from MIT to **Apache 2.0**, across every metadata file, plus surfaces the licence in the README and the in-app About / Cite documentation pages.

Companion PR on `ldaca-wordflow-backend`: https://github.com/Australian-Text-Analytics-Platform/ldaca-wordflow-backend/pull/2 — that one ships the same LICENSE + NOTICE + PEP 639 metadata for the published PyPI distribution. This PR bumps the `backend` submodule pointer to that branch.

Both PRs are **draft / for discussion ahead of the upcoming workshop**. They land together (or not at all) and would ship in a v0.5.2 release.

## Why Apache-2.0 over MIT

Apache-2.0 is permissive in the same spirit as MIT (use freely, modify freely, redistribute freely, commercially too) but adds:

1. **Explicit patent grant** from contributors covering claims their contribution would otherwise infringe. Material for a research tool that may pick up commercial use downstream, where MIT's bare-bones grant could leave patent risk hanging.
2. **Explicit contributor terms** (§5) — gives the project a lightweight built-in contributor agreement without needing a separate CLA. Helps with the external-contributor model LDaCA + ATAP already use.
3. **NOTICE convention** — Apache 2.0 has a documented `NOTICE` mechanism for institutional attribution (LDaCA / ARDC / NCRIS / ATAP origin / Sydney Informatics Hub / Sydney Corpus Lab). MIT does not.
4. **Better fit with ARDC's standard guidance** for funded software (permissive open-source with explicit attribution preservation).

All Wordflow runtime dependencies are already permissive (MIT or MIT/Apache-2.0 dual): `polars`, `polars-text`, `docworkspace`, `FastAPI`, `React`, `Tauri`, `tokenizers`, `bertopic`, and more. Apache-2.0 is fully compatible with all of them downstream — no licence-incompatibility regressions.

## What changes

### Licence + attribution files

- `LICENSE` — canonical Apache 2.0 text (vendored from a known-good Apache 2.0 dependency, 202-line verbatim).
- `NOTICE` — institutional attribution: Sydney Informatics Hub, Sydney Corpus Lab, LDaCA / ARDC / NCRIS context, ATAP lineage. Also lists the third-party permissive components.

### Metadata

- `pyproject.toml` (workspace) — adds PEP 639 `license` + `license-files` (had no licence metadata before).
- `frontend/package.json` — `"MIT"` → `"Apache-2.0"`.
- `frontend/src-tauri/Cargo.toml` — adds `license = "Apache-2.0"` so Cargo stamps it into the desktop binary metadata too.

### User-facing docs

- `README.md` — new "## License" section near the bottom of the file with a short summary and links to LICENSE / NOTICE.
- `frontend/public/information/general.md` (the in-app **About Wordflow** panel) — appended "## License" section so workshop attendees see the licence at a glance.
- `frontend/public/references/general.md` (the in-app **Cite LDaCA Wordflow** panel) — inserted "## License" section above the existing © footer.

### Submodule pointer bump

- `backend` → companion backend PR's tip, which:
  - Mirrors LICENSE + NOTICE + PEP 639 metadata for the published `ldaca-wordflow` PyPI distribution.
  - Rebuilds the frontend bundle so the in-app About + Cite panels ship the new "## License" section to PyPI / Tauri users.

## NOT changing

- `polars-text` and `docworkspace` keep their existing licences. They are standalone library dependencies with their own publishing pipelines; their licence story is a separate decision.

## Test plan

- [x] Built the frontend bundle locally; new "## License" sections render in About + Cite panels.
- [x] Built the backend wheel locally; METADATA reads `License-Expression: Apache-2.0` with both LICENSE + NOTICE attached.
- [ ] Review the LICENSE + NOTICE text for institutional accuracy (years, copyright holders, attribution wording).
- [ ] Land both PRs together; cut v0.5.2 release with the licence change as the headline item.

## Open questions for the reviewer

1. **Copyright holder line in NOTICE.** Current draft: "The University of Sydney and LDaCA Wordflow contributors". Should this be more specific (e.g. naming the LDaCA consortium, or just "Sydney Informatics Hub"), or kept broad?
2. **Year range.** Currently "2024-2026". Is 2024 the right starting year, or should it reach back to ATAP-era (2022-3) work that has been folded in?
3. **Workshop timing.** If this needs to land before the workshop, target a v0.5.2 cut date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)