### PR TITLE
Data-block colouring, token-frequency result ordering, and double-click add

### DIFF
--- a/frontend/src/components/layout/WorkspaceNodeList.tsx
+++ b/frontend/src/components/layout/WorkspaceNodeList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import type React from 'react';
 import { cn } from '@/lib/utils';
 import { normalizeNodeAccentColor } from '@/lib/nodeColor';
+import { GREY, toBgColor } from '@/features/views/common/vizPalette';
 import { useFreshNodesStore } from '@/stores/freshNodesStore';
 import { usePinnedNodesStore } from '@/stores/pinnedNodesStore';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -151,9 +152,11 @@ function WorkspaceNodeList({
                 const isPinned = pinnedIdSet.has(node.id);
                 const pinnedRowAction = isPinned ? renderPinnedRowAction(node) : null;
                 const rowActions = renderRowActions(node);
-                // Persisted node colour drawn as a thin left spine on the row so
-                // the right-aligned name and its left fade stay fully legible.
-                const accentColor = normalizeNodeAccentColor(node.color);
+                // Block colour: the row is always filled with the light background
+                // tint of the block's colour (grey for unset / un-analysed blocks),
+                // with a 4px FG spine on the left; a selected row also takes the
+                // full FG colour as its border.
+                const effectiveColor = normalizeNodeAccentColor(node.color) ?? GREY;
 
                 return (
                   <Tooltip key={node.id}>
@@ -178,22 +181,30 @@ function WorkspaceNodeList({
                         {/* Inner box carries the border/background. */}
                         <div
                           className={cn(
-                            'relative flex items-center gap-2 overflow-visible rounded-md border bg-background/70 px-2 py-1 text-xs transition-colors duration-150 ease-out group-focus-visible/row:ring-1 group-focus-visible/row:ring-ring',
+                            'relative flex items-center gap-2 overflow-visible rounded-md border px-2 py-1 text-xs transition-colors duration-150 ease-out group-focus-visible/row:ring-1 group-focus-visible/row:ring-ring',
                             isPinned && pinnedRowAction && 'pl-8',
                             checked
-                              ? 'border-primary/70 bg-primary/10 ring-1 ring-primary/20'
-                              : 'border-border/60 group-hover/row:border-border group-hover/row:bg-accent/60',
+                              ? 'ring-1 ring-primary/20'
+                              : 'border-border/60 group-hover/row:border-border',
                           )}
                           data-testid={`workspace-node-row-${node.id}`}
-                          style={
-                            accentColor
+                          style={{
+                            backgroundColor: toBgColor(effectiveColor),
+                            // Selected: full FG-colour border. Unselected keeps the
+                            // neutral border class; both keep the 4px FG left spine.
+                            // Use per-side longhands (not the `borderColor`
+                            // shorthand) so they never conflict with borderLeftColor.
+                            ...(checked
                               ? {
-                                  borderLeftColor: accentColor,
-                                  borderLeftWidth: '4px',
-                                  borderLeftStyle: 'solid',
+                                  borderTopColor: effectiveColor,
+                                  borderRightColor: effectiveColor,
+                                  borderBottomColor: effectiveColor,
                                 }
-                              : undefined
-                          }
+                              : {}),
+                            borderLeftColor: effectiveColor,
+                            borderLeftWidth: '4px',
+                            borderLeftStyle: 'solid',
+                          }}
                         >
                           {pinnedRowAction && (
                             <div

--- a/frontend/src/components/layout/__tests__/WorkspaceNodeList.test.tsx
+++ b/frontend/src/components/layout/__tests__/WorkspaceNodeList.test.tsx
@@ -84,7 +84,7 @@ describe('WorkspaceNodeList', () => {
     expect(screen.getByText('Corpus')).toBeInTheDocument();
   });
 
-  it('renders no accent style for a node without a color', () => {
+  it('defaults an uncoloured node to a grey spine and a background fill', () => {
     render(
       <WorkspaceNodeList
         workspaceId="workspace-1"
@@ -95,8 +95,12 @@ describe('WorkspaceNodeList', () => {
       />,
     );
 
+    // Un-analysed blocks default to grey: a 4px left spine plus a light fill,
+    // rather than no accent at all.
     const accentBox = screen.getByTestId('workspace-node-row-node-1');
-    expect(accentBox.style.borderLeftWidth).toBe('');
+    expect(accentBox).toHaveStyle({ borderLeftWidth: '4px' });
+    expect(accentBox.style.borderLeftColor).not.toBe('');
+    expect(accentBox.style.backgroundColor).not.toBe('');
   });
 
   it('groups pinned nodes before selected non-pinned nodes and regular nodes', () => {

--- a/frontend/src/features/views/common/__tests__/vizPalette.test.ts
+++ b/frontend/src/features/views/common/__tests__/vizPalette.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  GREY,
+  RANDOMIZABLE_FG,
+  VIZ_PALETTE,
+  VIZ_PALETTE_BG,
+  pickRandomColor,
+  toBgColor,
+} from '../vizPalette';
+
+/** WCAG relative luminance of an #rrggbb colour. */
+function luminance(hex: string): number {
+  const linear = (i: number): number => {
+    const c = parseInt(hex.slice(i, i + 2), 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * linear(1) + 0.7152 * linear(3) + 0.0722 * linear(5);
+}
+
+/** Contrast ratio of black text (#000000) against a background colour. */
+const blackTextContrast = (bg: string): number => (luminance(bg) + 0.05) / 0.05;
+
+describe('toBgColor', () => {
+  it('produces a light tint with strong black-text contrast for every FG colour', () => {
+    for (const fg of VIZ_PALETTE) {
+      const bg = toBgColor(fg);
+      expect(bg).toMatch(/^#[0-9a-f]{6}$/);
+      // Comfortably above WCAG AAA (7:1) so black text is always legible.
+      expect(blackTextContrast(bg)).toBeGreaterThan(7);
+    }
+  });
+
+  it('is index-aligned with the precomputed VIZ_PALETTE_BG', () => {
+    expect(VIZ_PALETTE_BG).toEqual(VIZ_PALETTE.map((c) => toBgColor(c)));
+  });
+
+  it('returns invalid input unchanged', () => {
+    expect(toBgColor('not-a-color')).toBe('not-a-color');
+  });
+});
+
+describe('pickRandomColor', () => {
+  it('never returns grey', () => {
+    expect(RANDOMIZABLE_FG).not.toContain(GREY);
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    expect(pickRandomColor()).not.toBe(GREY);
+    vi.restoreAllMocks();
+  });
+
+  it('avoids colours already in use', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const used = RANDOMIZABLE_FG.slice(0, 1);
+    const picked = pickRandomColor(used);
+    expect(picked).not.toBe(RANDOMIZABLE_FG[0]);
+    expect(RANDOMIZABLE_FG).toContain(picked);
+    vi.restoreAllMocks();
+  });
+
+  it('falls back to a valid colour when every palette colour is used', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const picked = pickRandomColor(RANDOMIZABLE_FG);
+    expect(RANDOMIZABLE_FG).toContain(picked);
+    vi.restoreAllMocks();
+  });
+});

--- a/frontend/src/features/views/common/hooks/__tests__/useNodeColorControls.test.tsx
+++ b/frontend/src/features/views/common/hooks/__tests__/useNodeColorControls.test.tsx
@@ -1,11 +1,17 @@
-import { act, renderHook } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { useNodeColorControls } from '../useNodeColorControls';
+import { GREY, RANDOMIZABLE_FG } from '../../vizPalette';
 import { projectWorkspaceNodeMetadata } from '@/features/workspace/common/workspaceNodeMetadata';
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe('useNodeColorControls', () => {
-  it('derives colours from persisted node metadata and posts defaults for missing colours', async () => {
+  it('keeps persisted colours and pre-fills a temporary non-grey colour for unset blocks', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
     const persistNodeColor = vi.fn().mockResolvedValue(undefined);
     const { result } = renderHook(() =>
       useNodeColorControls({
@@ -18,20 +24,44 @@ describe('useNodeColorControls', () => {
       }),
     );
 
-    expect(result.current.nodeColors).toEqual({
-      'node-1': '#111111',
-      'node-2': '#dc2626',
+    await waitFor(() => {
+      expect(result.current.nodeColors['node-2']).not.toBe(GREY);
     });
-
-    await act(async () => {
-      await result.current.ensureNodeColors();
-    });
-
-    expect(persistNodeColor).toHaveBeenCalledTimes(1);
-    expect(persistNodeColor).toHaveBeenCalledWith('node-2', '#dc2626');
+    expect(result.current.nodeColors['node-1']).toBe('#111111');
+    expect(RANDOMIZABLE_FG).toContain(result.current.nodeColors['node-2']);
+    // The preview is NOT persisted — graph/sidebar stay untouched until a run.
+    expect(persistNodeColor).not.toHaveBeenCalled();
   });
 
-  it('posts picked colours immediately without waiting for an analysis request', async () => {
+  it('pre-fills distinct temporary colours for sibling unset blocks', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const persistNodeColor = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useNodeColorControls({
+        nodeIds: ['a', 'b', 'c'],
+        nodes: [
+          projectWorkspaceNodeMetadata({ id: 'a', name: 'A' }),
+          projectWorkspaceNodeMetadata({ id: 'b', name: 'B' }),
+          projectWorkspaceNodeMetadata({ id: 'c', name: 'C' }),
+        ],
+        persistNodeColor,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.nodeColors.c).not.toBe(GREY);
+    });
+    const previews = ['a', 'b', 'c'].map((id) => result.current.nodeColors[id]);
+    expect(new Set(previews).size).toBe(3); // distinct
+    previews.forEach((color) => {
+      expect(color).not.toBe(GREY);
+      expect(RANDOMIZABLE_FG).toContain(color);
+    });
+    expect(persistNodeColor).not.toHaveBeenCalled();
+  });
+
+  it('commits the previewed colour to Node.color only on ensureNodeColors', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
     const persistNodeColor = vi.fn().mockResolvedValue(undefined);
     const { result } = renderHook(() =>
       useNodeColorControls({
@@ -41,11 +71,71 @@ describe('useNodeColorControls', () => {
       }),
     );
 
+    await waitFor(() => {
+      expect(result.current.nodeColors['node-1']).not.toBe(GREY);
+    });
+    const preview = result.current.nodeColors['node-1'];
+    expect(persistNodeColor).not.toHaveBeenCalled();
+
     await act(async () => {
-      await result.current.setNodeColor('node-1', '#ABCDEF');
+      await result.current.ensureNodeColors();
+    });
+
+    expect(persistNodeColor).toHaveBeenCalledTimes(1);
+    expect(persistNodeColor).toHaveBeenCalledWith('node-1', preview);
+  });
+
+  it('reverts (discards) the preview when a block is deselected without running', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const persistNodeColor = vi.fn().mockResolvedValue(undefined);
+    const { result, rerender } = renderHook(
+      (props: { ids: string[] }) =>
+        useNodeColorControls({
+          nodeIds: props.ids,
+          nodes: [
+            projectWorkspaceNodeMetadata({ id: 'node-1', name: 'One' }),
+            projectWorkspaceNodeMetadata({ id: 'node-2', name: 'Two' }),
+          ],
+          persistNodeColor,
+        }),
+      { initialProps: { ids: ['node-1', 'node-2'] } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.nodeColors['node-2']).not.toBe(GREY);
+    });
+
+    // Deselect node-2 before any run.
+    rerender({ ids: ['node-1'] });
+
+    await waitFor(() => {
+      expect(result.current.nodeColors['node-2']).toBeUndefined();
+    });
+    // Nothing was ever persisted, so the block reverts to its (grey) default.
+    expect(persistNodeColor).not.toHaveBeenCalled();
+  });
+
+  it('setNodeColor edits the preview only (no immediate persistence)', async () => {
+    const persistNodeColor = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useNodeColorControls({
+        nodeIds: ['node-1'],
+        nodes: [projectWorkspaceNodeMetadata({ id: 'node-1', name: 'Corpus' })],
+        persistNodeColor,
+      }),
+    );
+
+    act(() => {
+      result.current.setNodeColor('node-1', '#ABCDEF');
     });
 
     expect(result.current.nodeColors['node-1']).toBe('#abcdef');
+    expect(persistNodeColor).not.toHaveBeenCalled();
+
+    // The manual pick is what gets committed on run.
+    await act(async () => {
+      await result.current.ensureNodeColors();
+    });
     expect(persistNodeColor).toHaveBeenCalledWith('node-1', '#abcdef');
   });
 });

--- a/frontend/src/features/views/common/hooks/useNodeColorControls.ts
+++ b/frontend/src/features/views/common/hooks/useNodeColorControls.ts
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { WorkspaceNodeMetadata } from '@/features/workspace/common/workspaceNodeMetadata';
-import { VIZ_PALETTE, vizColorMapForNodes } from '../vizPalette';
+import { GREY, VIZ_PALETTE, pickRandomColor } from '../vizPalette';
 
 const HEX_COLOR_RE = /^#[0-9a-f]{6}$/i;
 
@@ -26,61 +26,132 @@ const withoutNodeColor = (
   return next;
 };
 
+const sameColorMap = (a: Record<string, string>, b: Record<string, string>): boolean => {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  return aKeys.length === bKeys.length && bKeys.every((key) => a[key] === b[key]);
+};
+
 /**
- * Adapts persisted workspace-node colours for colour-coded analysis tabs.
+ * Adapts workspace-node colours for colour-coded analysis tabs.
  * Used by: token frequency, concordance, and topic modelling because their
- * selected source nodes drive chart/table colours and missing colours must be
- * written to ``Node.color`` before an analysis starts.
- * Flow: derive palette defaults from node order, prefer valid ``node.color``
- * metadata, layer immediate optimistic picks, and expose a run-time guard that
- * posts defaults for selected nodes that still lack a persisted colour.
+ * selected source nodes drive chart/table colours.
+ *
+ * Colour model — preview then commit:
+ * - A block's durable colour lives on ``Node.color`` (grey / unset until it has
+ *   been through an analysis). The graph card and sidebar row read that, so an
+ *   un-analysed block stays grey there.
+ * - When a block is added to a tool's selection it gets a *temporary* colour
+ *   (random, non-grey, distinct from its siblings) held only in local
+ *   ``preview`` state — so the tool UI shows a pre-filled colour and the user
+ *   can preview the result. Deselecting the block discards the temporary colour
+ *   (revert). The temporary colour is **not** persisted, so graph/sidebar are
+ *   unaffected until a run.
+ * - ``ensureNodeColors`` (called just before an analysis runs) commits each
+ *   selected block's previewed colour to ``Node.color``, at which point the
+ *   graph/sidebar pick it up.
+ * - ``setNodeColor`` (the picker) also stays a preview edit — it updates the
+ *   temporary colour and commits on the next run.
  */
 export function useNodeColorControls({
   nodeIds,
   nodes,
   persistNodeColor,
 }: NodeColorControlsParams) {
-  const [optimisticNodeColors, setOptimisticNodeColors] = useState<Record<string, string>>({});
+  // Temporary, not-yet-persisted preview colours, keyed by node id.
+  const [previewColors, setPreviewColors] = useState<Record<string, string>>({});
 
-  const defaultNodeColors = vizColorMapForNodes(nodeIds);
   const nodeById = new Map(nodes.map((node) => [node.id, node] as const));
-  const nodeColors = { ...defaultNodeColors };
+  // Preview colour wins in the tool UI; otherwise the persisted colour; else grey.
+  const nodeColors: Record<string, string> = {};
   nodeIds.forEach((nodeId) => {
     const persisted = normalizeHexColor(nodeById.get(nodeId)?.color);
-    const optimistic = optimisticNodeColors[nodeId];
-    nodeColors[nodeId] = optimistic ?? persisted ?? nodeColors[nodeId] ?? '#000000';
+    nodeColors[nodeId] = previewColors[nodeId] ?? persisted ?? GREY;
   });
 
-  const setNodeColor = async (nodeId: string, color: string) => {
+  const setNodeColor = (nodeId: string, color: string) => {
     const normalized = normalizeHexColor(color);
     if (!nodeId || !normalized) return;
-    setOptimisticNodeColors((prev) =>
+    // Preview edit only; committed to Node.color on the next run.
+    setPreviewColors((prev) =>
       prev[nodeId] === normalized ? prev : { ...prev, [nodeId]: normalized },
     );
-    if (persistNodeColor) {
-      await Promise.resolve(persistNodeColor(nodeId, normalized)).catch(() => {
-        setOptimisticNodeColors((prev) => withoutNodeColor(prev, nodeId));
-      });
-    }
   };
 
+  // Signature of the selection + each block's persisted colour. Changes when a
+  // block is added/removed or a colour is committed, but NOT when only the
+  // preview map changes — so reconciliation runs once per selection change
+  // without looping.
+  const selectionSignature = nodeIds
+    .map((nodeId) => `${nodeId}:${normalizeHexColor(nodeById.get(nodeId)?.color) ?? ''}`)
+    .join('|');
+
+  // Reconcile the preview map with the current selection: keep previews for
+  // still-selected blocks, drop them for deselected ones (revert), and pre-fill
+  // a temporary colour for any newly-selected block that has none. No
+  // persistence happens here — this only feeds the tool UI.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- deliberate sync: reconcile the temporary preview map with the selection; guarded by sameColorMap so it settles in one pass and never loops.
+    setPreviewColors((prev) => {
+      const selected = nodeIds.filter(Boolean);
+      const selectedSet = new Set(selected);
+      const used = new Set<string>();
+      selected.forEach((nodeId) => {
+        const persisted = normalizeHexColor(nodeById.get(nodeId)?.color);
+        if (persisted) used.add(persisted.toLowerCase());
+      });
+      const next: Record<string, string> = {};
+      // Keep existing previews (auto or user-picked) for still-selected blocks.
+      for (const [nodeId, color] of Object.entries(prev)) {
+        if (selectedSet.has(nodeId)) {
+          next[nodeId] = color;
+          used.add(color.toLowerCase());
+        }
+      }
+      // Pre-fill a temporary colour for selected blocks that have neither a
+      // persisted colour nor a preview yet.
+      selected.forEach((nodeId) => {
+        if (next[nodeId] || normalizeHexColor(nodeById.get(nodeId)?.color)) return;
+        const color = pickRandomColor(used);
+        used.add(color.toLowerCase());
+        next[nodeId] = color;
+      });
+      return sameColorMap(prev, next) ? prev : next;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- selectionSignature captures the meaningful inputs (selected ids + their persisted colours); depending on nodeById/previewColors would re-run every render.
+  }, [selectionSignature]);
+
   const ensureNodeColors = async () => {
+    if (!persistNodeColor) return;
+    const persist = persistNodeColor;
+    const used = new Set<string>();
+    nodeIds.forEach((nodeId) => {
+      const existing = normalizeHexColor(nodeById.get(nodeId)?.color) ?? previewColors[nodeId];
+      if (existing) used.add(existing.toLowerCase());
+    });
     const updates: Promise<void>[] = [];
     nodeIds.forEach((nodeId) => {
       if (!nodeId) return;
-      if (normalizeHexColor(nodeById.get(nodeId)?.color) || optimisticNodeColors[nodeId]) {
-        return;
+      const persisted = normalizeHexColor(nodeById.get(nodeId)?.color);
+      // The colour the user previewed for this block (falls back to allocating
+      // one if a run happens before the preview settled).
+      let target = previewColors[nodeId] ?? persisted;
+      if (!target) {
+        const allocated = pickRandomColor(used);
+        target = allocated;
+        setPreviewColors((prev) =>
+          prev[nodeId] === allocated ? prev : { ...prev, [nodeId]: allocated },
+        );
       }
-      const fallback = defaultNodeColors[nodeId];
-      if (!fallback || !persistNodeColor) return;
-      setOptimisticNodeColors((prev) =>
-        prev[nodeId] === fallback ? prev : { ...prev, [nodeId]: fallback },
-      );
+      used.add(target.toLowerCase());
+      // Already committed with this exact colour — nothing to do.
+      if (persisted && persisted === target) return;
+      const committed = target;
       updates.push(
-        Promise.resolve(persistNodeColor(nodeId, fallback))
+        Promise.resolve(persist(nodeId, committed))
           .then(() => undefined)
           .catch((error: unknown) => {
-            setOptimisticNodeColors((prev) => withoutNodeColor(prev, nodeId));
+            setPreviewColors((prev) => withoutNodeColor(prev, nodeId));
             throw error;
           }),
       );

--- a/frontend/src/features/views/common/vizPalette.ts
+++ b/frontend/src/features/views/common/vizPalette.ts
@@ -1,15 +1,23 @@
 /**
- * Static colour palette for in-result data visualisations (e.g. the
- * concordance dispersion plot's matched-term colours and the combined
- * results table's per-source colours).
+ * Static colour palette for data-block (workspace node) colouring and in-result
+ * data visualisations (e.g. the concordance dispersion plot's matched-term
+ * colours and the combined results table's per-source colours).
  *
- * Callers index into this array by position (term index / source index) to get
- * a stable, repeatable fallback colour for a chart or table. Analysis tabs
- * that expose source-node colour controls write user choices to ``Node.color``
- * and use this palette only when a selected node does not yet have a colour.
+ * Two roles per colour:
+ * - FG (`VIZ_PALETTE`): the saturated identity colour. Used for the node card's
+ *   left accent spine, the sidebar row spine, word-cloud text, chart series,
+ *   and as the value persisted on ``Node.color``.
+ * - BG (`toBgColor` / `VIZ_PALETTE_BG`): a light tint of the same hue for
+ *   filling backgrounds behind black text (frequency list rows, node card
+ *   fills, sidebar row fills). Every BG tint keeps black-text contrast well
+ *   above WCAG AAA (>=15:1), so dark text is always legible on it.
  *
- * Used by: concordance/ConcordanceFeature.tsx for matched-term and
- * per-source colour maps.
+ * ``GREY`` is the default colour for new / un-analysed data blocks and is
+ * excluded from random allocation (`RANDOMIZABLE_FG`); a user may still pick it
+ * manually, in which case it persists like any other choice.
+ *
+ * Used by: useNodeColorControls (allocation), CustomNode + WorkspaceNodeList
+ * (fills/spines), token-frequency result views, and analysis chart legends.
  */
 export const VIZ_PALETTE: string[] = [
   '#2563eb',
@@ -26,12 +34,58 @@ export const VIZ_PALETTE: string[] = [
   '#6b7280',
 ];
 
+/** Neutral grey — the default for new/un-analysed blocks; excluded from random allocation. */
+export const GREY = '#6b7280';
+
+/** FG colours eligible for random allocation to a freshly-analysed block (grey excluded). */
+export const RANDOMIZABLE_FG: string[] = VIZ_PALETTE.filter((color) => color !== GREY);
+
+const HEX_COLOR_RE = /^#[0-9a-f]{6}$/i;
+
+/** Fraction of the source colour blended over white to make its background tint. */
+const BG_COLOR_MIX = 0.18;
+
+const clampChannel = (value: number): number => Math.max(0, Math.min(255, Math.round(value)));
+
+/**
+ * Derives a light background tint from any ``#rrggbb`` colour by mixing
+ * ``BG_COLOR_MIX`` of the colour over white. Keeps the hue identity while
+ * guaranteeing high contrast for black text (validated >=15:1 for every FG
+ * palette colour). Works for custom user-picked colours too, not just the
+ * palette. Returns the input unchanged when it is not a valid hex colour.
+ * Used by: node card fills, sidebar row fills, and the frequency list row bars.
+ */
+export function toBgColor(fg: string, mix: number = BG_COLOR_MIX): string {
+  if (!HEX_COLOR_RE.test(fg)) return fg;
+  const hex = fg.slice(1);
+  const channels = [0, 2, 4].map((i) => parseInt(hex.slice(i, i + 2), 16));
+  const tinted = channels.map((c) => clampChannel(c * mix + 255 * (1 - mix)));
+  return `#${tinted.map((c) => c.toString(16).padStart(2, '0')).join('')}`;
+}
+
+/** Precomputed background tints for the FG palette, index-aligned with `VIZ_PALETTE`. */
+export const VIZ_PALETTE_BG: string[] = VIZ_PALETTE.map((color) => toBgColor(color));
+
+/**
+ * Picks a colour to assign to a not-yet-coloured block, at random from
+ * `RANDOMIZABLE_FG` (grey excluded), avoiding any colour in ``used`` so blocks
+ * selected together in one analysis tool get distinct colours. Falls back to a
+ * random non-grey colour (allowing a repeat) once every palette colour is taken.
+ * Used by: useNodeColorControls.ensureNodeColors when an analysis run assigns
+ * durable colours to its still-uncoloured source blocks.
+ */
+export function pickRandomColor(used: Iterable<string> = []): string {
+  const taken = new Set(Array.from(used, (c) => c.toLowerCase()));
+  const available = RANDOMIZABLE_FG.filter((color) => !taken.has(color.toLowerCase()));
+  const pool = available.length > 0 ? available : RANDOMIZABLE_FG;
+  const index = Math.floor(Math.random() * pool.length);
+  return pool[index] ?? pool[0] ?? VIZ_PALETTE[0] ?? GREY;
+}
+
 /**
  * Build default ``nodeId → colour`` assignments by selected-node position.
- * Used as the fallback map for chart legends/series in analysis tabs before
- * caller-owned ``Node.color`` values are layered over the defaults.
- *
- * Used by: analysis feature tabs that colour chart series by source node.
+ * Retained for legacy chart-series fallbacks; node colouring now defaults unset
+ * blocks to {@link GREY} and allocates real colours via {@link pickRandomColor}.
  */
 export function vizColorMapForNodes(nodeIds: readonly string[]): Record<string, string> {
   const map: Record<string, string> = {};

--- a/frontend/src/features/views/token-frequency/__tests__/tokenFrequencyAdapters.test.ts
+++ b/frontend/src/features/views/token-frequency/__tests__/tokenFrequencyAdapters.test.ts
@@ -1,5 +1,39 @@
 import { describe, expect, it } from 'vitest';
-import { deriveNodeDisplayResults, type NormalizedNodeResult } from '../tokenFrequencyAdapters';
+import {
+  computeAnalysisNodeIds,
+  deriveNodeDisplayResults,
+  type NormalizedNodeResult,
+} from '../tokenFrequencyAdapters';
+
+describe('computeAnalysisNodeIds', () => {
+  it('orders by the selection panel, not the study-last request/echo order', () => {
+    // Selection panel order is [stories, comments]; the backend echo puts the
+    // study corpus last -> [comments, stories]. Display must follow selection.
+    const selection = [{ nodeId: 'stories' }, { nodeId: 'comments' }];
+    const backendEcho = ['comments', 'stories'];
+    const lastCompare = ['comments', 'stories'];
+
+    expect(computeAnalysisNodeIds(backendEcho, lastCompare, selection)).toEqual([
+      'stories',
+      'comments',
+    ]);
+  });
+
+  it('appends result nodes not present in the current selection (no duplicates)', () => {
+    const selection = [{ nodeId: 'stories' }];
+    expect(computeAnalysisNodeIds(['comments', 'stories'], [], selection)).toEqual([
+      'stories',
+      'comments',
+    ]);
+  });
+
+  it('falls back to the backend echo order when there is no selection', () => {
+    expect(computeAnalysisNodeIds(['comments', 'stories'], [], [])).toEqual([
+      'comments',
+      'stories',
+    ]);
+  });
+});
 
 /** Builds descending token-frequency rows for adapter boundary tests. */
 const buildRows = (tokens: string[]) =>

--- a/frontend/src/features/views/token-frequency/components/results/TokenFrequencySingleTokenSection.tsx
+++ b/frontend/src/features/views/token-frequency/components/results/TokenFrequencySingleTokenSection.tsx
@@ -7,6 +7,7 @@ import { Download } from 'lucide-react';
 import { Wordcloud } from '@visx/wordcloud';
 import { Text } from '@visx/text';
 import { useElementWidth } from '@/lib/useElementWidth';
+import { toBgColor } from '@/features/views/common/vizPalette';
 
 interface TokenFrequencySingleTokenSectionProps {
   nodeDisplayResults: NodeResultView[];
@@ -371,7 +372,7 @@ const TokenFrequencySingleTokenSectionInner = ({
                       >
                         <span
                           className="absolute inset-y-0 left-0 rounded bg-primary/20 group-hover:bg-primary/30"
-                          style={{ width: `${String(widthPct)}%`, backgroundColor: color }}
+                          style={{ width: `${String(widthPct)}%`, backgroundColor: toBgColor(color) }}
                         />
                         <span className="relative z-10 block truncate px-2 text-sm font-medium">
                           {row.token}

--- a/frontend/src/features/views/token-frequency/components/results/TokenFrequencyUnifiedTokenSection.tsx
+++ b/frontend/src/features/views/token-frequency/components/results/TokenFrequencyUnifiedTokenSection.tsx
@@ -109,12 +109,16 @@ const TokenFrequencyUnifiedTokenSectionInner = ({
   }
 
   const isComparative = normalizedNodeResults.length === 2 && lastCompareNodeIds.length === 2;
-  const nodeAResult = nodeDisplayResults[0] ?? normalizedNodeResults[0] ?? null;
-  const nodeBResult = nodeDisplayResults[1] ?? normalizedNodeResults[1] ?? null;
-  const nodeAId = nodeAResult?.nodeId ?? lastCompareNodeIds[0] ?? '';
-  const nodeBId = nodeBResult?.nodeId ?? lastCompareNodeIds[1] ?? '';
-  const nodeAName = nodeAResult?.displayName ?? computeDisplayName(nodeAId, nodeAId);
-  const nodeBName = nodeBResult?.displayName ?? computeDisplayName(nodeBId, nodeBId);
+  // The gradient maps each token's proportion (reference %) through `blend`
+  // below, where blend(1) === colorA. So nodeA MUST be the REFERENCE corpus and
+  // nodeB the STUDY corpus — independent of the per-node display order, which
+  // now follows the selection panel. The backend submits the study corpus last,
+  // so lastCompareNodeIds[0] = reference and [1] = study.
+  const resultById = new Map(nodeDisplayResults.map((result) => [result.nodeId, result]));
+  const nodeAId = lastCompareNodeIds[0] ?? nodeDisplayResults[0]?.nodeId ?? '';
+  const nodeBId = lastCompareNodeIds[1] ?? nodeDisplayResults[1]?.nodeId ?? '';
+  const nodeAName = resultById.get(nodeAId)?.displayName ?? computeDisplayName(nodeAId, nodeAId);
+  const nodeBName = resultById.get(nodeBId)?.displayName ?? computeDisplayName(nodeBId, nodeBId);
   const nodeAColor = getColorForNode(nodeAId || nodeAName, 0);
   const nodeBColor = getColorForNode(nodeBId || nodeBName, 1);
 

--- a/frontend/src/features/views/token-frequency/tokenFrequencyAdapters.ts
+++ b/frontend/src/features/views/token-frequency/tokenFrequencyAdapters.ts
@@ -118,12 +118,19 @@ export const computeAnalysisNodeIds = (
   lastCompareNodeIds: string[],
   nodeColumnSelections: { nodeId: string }[],
 ): string[] => {
+  // Display order follows the current selection panel (nodeColumnSelections) so
+  // the per-node results line up left-to-right with the "Selected Data Blocks"
+  // panel. The study-corpus is submitted last for the backend comparison, so the
+  // request/echo order (paramsNodeIds, lastCompareNodeIds) must NOT drive display
+  // order — it only fills in any node not currently in the panel. The resulting
+  // set is unchanged (union + dedupe); only the ORDER differs, and
+  // normalizeNodeResults matches each node's data by id, so this is display-only.
   const combined: (string | null | undefined)[] = [];
+  combined.push(...nodeColumnSelections.map((sel) => sel.nodeId));
   if (Array.isArray(paramsNodeIds)) {
     combined.push(...(paramsNodeIds as string[]));
   }
   combined.push(...lastCompareNodeIds);
-  combined.push(...nodeColumnSelections.map((sel) => sel.nodeId));
 
   const seen = new Set<string>();
   const deduped: string[] = [];

--- a/frontend/src/features/workspace/graph-view/components/CustomNode.tsx
+++ b/frontend/src/features/workspace/graph-view/components/CustomNode.tsx
@@ -21,6 +21,7 @@ import {
 import type { WorkspaceGraphNodeCard } from '../graphNodeModel';
 import { cn } from '@/lib/utils';
 import { normalizeNodeAccentColor } from '@/lib/nodeColor';
+import { GREY, toBgColor } from '@/features/views/common/vizPalette';
 import { CUSTOM_NODE_TOOLBAR_BUTTON_CLASS, CustomNodeActionMenu } from './CustomNodeActionMenu';
 import { CustomNodeRenameForm } from './CustomNodeRenameForm';
 import {
@@ -181,14 +182,18 @@ function CustomNode({ id, data, selected }: NodeProps<ReactFlowNode<CustomNodeDa
   const nodeName = node.name;
   const nodeShape = node.shape;
 
-  // Optional per-node accent. A valid ``#rrggbb`` ``Node.color`` is drawn as a
-  // solid left spine on both the full and compact card so the colour reads
-  // clearly while the header/body backgrounds stay untouched for text contrast.
-  // Empty object when unset spreads to nothing, leaving the default card look.
-  const accentColor = normalizeNodeAccentColor(node.color);
-  const accentBorderStyle: React.CSSProperties = accentColor
-    ? { borderLeftColor: accentColor, borderLeftWidth: 6, borderLeftStyle: 'solid' }
-    : {};
+  // Per-node colour. A valid ``#rrggbb`` ``Node.color`` is the block's identity
+  // colour; unset / un-analysed blocks default to grey. The colour is drawn as a
+  // 6px solid left spine on both cards, and a light background tint (`fillColor`)
+  // fills the whole compact card when zoomed out, or just the header strip when
+  // zoomed in, so the colour reads clearly while black text stays legible.
+  const effectiveColor = normalizeNodeAccentColor(node.color) ?? GREY;
+  const accentBorderStyle: React.CSSProperties = {
+    borderLeftColor: effectiveColor,
+    borderLeftWidth: 6,
+    borderLeftStyle: 'solid',
+  };
+  const fillColor = toBgColor(effectiveColor);
 
   /** Shows this node's toolbar and claims singleton ownership so any other
    * node's hover toolbar hides at once. Called on node/toolbar mouse-enter. */
@@ -502,6 +507,9 @@ function CustomNode({ id, data, selected }: NodeProps<ReactFlowNode<CustomNodeDa
           minWidth: '180px',
           maxWidth: '300px',
           position: 'relative',
+          // Zoomed out: fill the whole compact card with the block's background
+          // tint, keeping the 6px FG spine and the normal selection border.
+          backgroundColor: fillColor,
           // ``isFresh`` red "new" dot rendered below marks newly-created
           // nodes the user hasn't acknowledged yet.
           ...accentBorderStyle,
@@ -549,12 +557,15 @@ function CustomNode({ id, data, selected }: NodeProps<ReactFlowNode<CustomNodeDa
       }}
     >
       {newDot}
-      {/* Node Header — primary-tinted strip when selected, muted otherwise. */}
+      {/* Node Header — zoomed in, only this top strip carries the block's
+          background tint; the body stays white so metadata reads cleanly.
+          The border keeps its normal selected/unselected treatment. */}
       <div
         className={cn(
           'flex items-start justify-between p-2 rounded-t-lg border-b-2 min-h-fit relative',
-          isSelected ? 'bg-primary/10 border-primary/40' : 'bg-muted border-border',
+          isSelected ? 'border-primary/40' : 'border-border',
         )}
+        style={{ backgroundColor: fillColor }}
       >
         <div className="flex items-center flex-1 mr-2">
           {isRenaming ? (

--- a/frontend/src/features/workspace/graph-view/components/WorkspaceGraphFeature.tsx
+++ b/frontend/src/features/workspace/graph-view/components/WorkspaceGraphFeature.tsx
@@ -129,6 +129,7 @@ export function WorkspaceGraphFeature({ fallback }: WorkspaceGraphFeatureProps) 
         onNodesChange={graph.handleNodesChange}
         onEdgesChange={graph.handleEdgesChange}
         onNodeClick={graph.handleNodeClick}
+        onNodeDoubleClick={graph.handleNodeDoubleClick}
         onPaneClick={graph.handlePaneClick}
         connectionLineType={graph.connectionLineType}
         defaultEdgeOptions={graph.defaultEdgeOptions}

--- a/frontend/src/features/workspace/graph-view/hooks/__tests__/useWorkspaceGraph.test.tsx
+++ b/frontend/src/features/workspace/graph-view/hooks/__tests__/useWorkspaceGraph.test.tsx
@@ -260,4 +260,24 @@ describe('useWorkspaceGraph', () => {
       'node-1',
     );
   });
+
+  it('adds a Data Block to the active tool on double-click, mirroring the + button', () => {
+    const { result } = renderHook(() => useWorkspaceGraph());
+    const event = { preventDefault: vi.fn(), stopPropagation: vi.fn() };
+
+    act(() => {
+      result.current.handleNodeDoubleClick(
+        event as unknown as Parameters<typeof result.current.handleNodeDoubleClick>[0],
+        { id: 'node-1' } as unknown as Parameters<typeof result.current.handleNodeDoubleClick>[1],
+      );
+    });
+
+    // Same add path as the node's "+" button (add-to-selection intent), not a
+    // selection toggle — works whether or not the block is selected.
+    expect(requestNodeInputAddMock).toHaveBeenCalledWith(
+      'workspace-a',
+      expect.any(String),
+      'node-1',
+    );
+  });
 });

--- a/frontend/src/features/workspace/graph-view/hooks/useWorkspaceGraph.ts
+++ b/frontend/src/features/workspace/graph-view/hooks/useWorkspaceGraph.ts
@@ -39,6 +39,7 @@ export interface WorkspaceGraphViewModel {
   totalNodes: number;
   canClearSelection: boolean;
   handleNodeClick: NodeMouseHandler;
+  handleNodeDoubleClick: NodeMouseHandler;
   handleNodesChange: ReturnType<typeof useNodesState<Node>>[2];
   handleEdgesChange: ReturnType<typeof useEdgesState<Edge>>[2];
   handlePaneClick: () => void;
@@ -432,6 +433,21 @@ export const useWorkspaceGraph = (): WorkspaceGraphViewModel => {
     [toggleNode, markInteracted],
   );
 
+  /**
+   * Double-click is a shortcut for the node's "+" Add-to-selection button: it
+   * adds the block to the active tool's inputs (works whether or not the block
+   * is currently selected). Single-click still toggles selection — the two
+   * single-clicks a double-click also fires net out to no selection change.
+   */
+  const handleNodeDoubleClick: NodeMouseHandler = useCallback(
+    (event, node) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (node.id) handleAddToSelection(node.id);
+    },
+    [handleAddToSelection],
+  );
+
   /** No-op connection handler because graph edges are backend-derived. */
   const handleConnect = useCallback((_connection: Connection) => {
     // No-op: graph edges are backend-derived, so user-drawn connections are ignored.
@@ -475,6 +491,7 @@ export const useWorkspaceGraph = (): WorkspaceGraphViewModel => {
     totalNodes,
     canClearSelection: selectedCount > 0,
     handleNodeClick,
+    handleNodeDoubleClick,
     handleNodesChange,
     handleEdgesChange: onEdgesChange,
     handlePaneClick,


### PR DESCRIPTION
Three frontend changes cherry-picked onto `dev` for review/merge. **Excludes** the follow-up tokenizer-default commit (`85ba7372`) since Alex has implemented that behaviour on his end.

## Commits
- **`5204c83f` feat(colour): data-block colouring** — BG-tint palette (validated for black-text contrast), grey default for un-analysed blocks, random non-grey sibling-distinct preview committed on run / reverted on deselect; graph-card + sidebar-row fills; token-frequency list-view BG tint.
- **`dfdfc843` fix(token-frequency): order results by selection** — per-node results (cloud + list) render in the selection-panel order instead of the study-last request order; comparative gradient pins nodeA/nodeB to reference/study by identity so reordering can't invert it.
- **`39d6c487` feat(graph): double-click a Data Block to add it to the active tool** — double-click mirrors the node's "+" add-to-selection; single-click still toggles selection; graph-view only.

## Notes for review
- These were re-implemented on top of the current `dev` architecture (after the big refactor), verified with `tsc`, eslint, and the affected test suites at the time.
- Given the substantial in-flight frontend/backend changes on `dev`, **expect merge conflicts** — flagging so they can be resolved on the dev side.
- The tokenizer-default work is intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)